### PR TITLE
Remove unnecessary "expand" in mask multiplication

### DIFF
--- a/models.py
+++ b/models.py
@@ -155,10 +155,8 @@ class EPiC_discriminator_mask(nn.Module):
         x_local = F.leaky_relu(self.fc_l2(x_local) + x_local)
 
         # global features: masked
-        x_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )  # mean over points dim.
-        x_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
+        x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
+        x_sum = (x_local * mask).sum(
             1, keepdim=False
         ) * self.sum_scale  # mean over points dim.
         x_global = torch.cat([x_mean, x_sum], 1)
@@ -171,11 +169,9 @@ class EPiC_discriminator_mask(nn.Module):
             x_global, x_local = self.nn_list[i](x_global, x_local, mask)
 
         # again masking global features
-        x_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )
+        x_mean = (x_local * mask).mean(1, keepdim=False)
         # mean over points dim.
-        x_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
+        x_sum = (x_local * mask).sum(
             1, keepdim=False
         ) * self.sum_scale  # sum over points dim.
         x = torch.cat([x_mean, x_sum, x_global], 1)
@@ -211,12 +207,8 @@ class EPiC_layer_cond_mask(nn.Module):
         latent_global = x_global.size(1)
 
         # communication between points is masked
-        x_pooled_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )
-        x_pooled_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
-            1, keepdim=False
-        ) * self.sum_scale
+        x_pooled_mean = (x_local * mask).mean(1, keepdim=False)
+        x_pooled_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x_pooledCATglobal = torch.cat(
             [x_pooled_mean, x_pooled_sum, x_global, cond_tensor], 1
         )
@@ -285,10 +277,8 @@ class EPiC_discriminator_cond_mask(nn.Module):
         x_local = F.leaky_relu(self.fc_l2(x_local) + x_local)
 
         # global features: masked
-        x_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )  # mean over points dim.
-        x_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
+        x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
+        x_sum = (x_local * mask).sum(
             1, keepdim=False
         ) * self.sum_scale  # mean over points dim.
         x_global = torch.cat([x_mean, x_sum, cond_tensor], 1)
@@ -302,10 +292,8 @@ class EPiC_discriminator_cond_mask(nn.Module):
             )  # contains residual connection
 
         # again masking global features
-        x_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )  # mean over points dim.
-        x_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
+        x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
+        x_sum = (x_local * mask).sum(
             1, keepdim=False
         ) * self.sum_scale  # sum over points dim.
         x = torch.cat([x_mean, x_sum, x_global, cond_tensor], 1)

--- a/models.py
+++ b/models.py
@@ -66,13 +66,9 @@ class EPiC_layer_mask(nn.Module):
 
         # calculate the mean along the axis that represents the sets
         # communication between points is masked
-        x_pooled_mean = (x_local * mask.expand(-1, -1, x_local.shape[2])).mean(
-            1, keepdim=False
-        )
+        x_pooled_mean = (x_local * mask).mean(1, keepdim=False)
         # calculate the sum pooling and scale with the factor "sum_scale"
-        x_pooled_sum = (x_local * mask.expand(-1, -1, x_local.shape[2])).sum(
-            1, keepdim=False
-        ) * self.sum_scale
+        x_pooled_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x_pooledCATglobal = torch.cat([x_pooled_mean, x_pooled_sum, x_global], 1)
         # new intermediate step
         x_global1 = F.leaky_relu(self.fc_global1(x_pooledCATglobal))
@@ -155,10 +151,10 @@ class EPiC_discriminator_mask(nn.Module):
         x_local = F.leaky_relu(self.fc_l2(x_local) + x_local)
 
         # global features: masked
-        x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
-        x_sum = (x_local * mask).sum(
-            1, keepdim=False
-        ) * self.sum_scale  # mean over points dim.
+        # mean over points dim.
+        x_mean = (x_local * mask).mean(1, keepdim=False)
+        # sum over points dim.
+        x_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x_global = torch.cat([x_mean, x_sum], 1)
         x_global = F.leaky_relu(self.fc_g1(x_global))
         x_global = F.leaky_relu(self.fc_g2(x_global))  # projecting down to latent size
@@ -201,7 +197,11 @@ class EPiC_layer_cond_mask(nn.Module):
 
     def forward(
         self, x_global, x_local, cond_tensor, mask
-    ):  # shapes: x_global[b,latent], x_local[b,n,latent_local]  points_tensor [b,cond_feats]   mask[B,N,1]
+    ):  # shapes: 
+        # - x_global[b,latent]
+        # - x_local[b,n,latent_local]  
+        # - points_tensor [b,cond_feats]   
+        # - mask[B,N,1]
         # mask: all non-padded values = True      all zero padded = False
         batch_size, n_points, latent_local = x_local.size()
         latent_global = x_global.size(1)
@@ -212,21 +212,17 @@ class EPiC_layer_cond_mask(nn.Module):
         x_pooledCATglobal = torch.cat(
             [x_pooled_mean, x_pooled_sum, x_global, cond_tensor], 1
         )
-        x_global1 = F.leaky_relu(
-            self.fc_global1(x_pooledCATglobal)
-        )  # new intermediate step
-        x_global = F.leaky_relu(
-            self.fc_global2(x_global1) + x_global
-        )  # with residual connection before AF
+        # new intermediate step
+        x_global1 = F.leaky_relu(self.fc_global1(x_pooledCATglobal))
+        # with residual connection before AF
+        x_global = F.leaky_relu(self.fc_global2(x_global1) + x_global)
 
         # point wise function does not need to be masked
-        x_global2local = x_global.view(-1, 1, latent_global).repeat(
-            1, n_points, 1
-        )  # first add dimension, than expand it
+        # first add dimension, than expand it
+        x_global2local = x_global.view(-1, 1, latent_global).repeat(1, n_points, 1)
         x_localCATglobal = torch.cat([x_local, x_global2local], 2)
-        x_local1 = F.leaky_relu(
-            self.fc_local1(x_localCATglobal)
-        )  # with residual connection before AF
+        # with residual connection before AF
+        x_local1 = F.leaky_relu(self.fc_local1(x_localCATglobal))
         x_local = F.leaky_relu(self.fc_local2(x_local1) + x_local)
 
         return x_global, x_local
@@ -269,33 +265,29 @@ class EPiC_discriminator_cond_mask(nn.Module):
         self.fc_g4 = self.weight_norm(nn.Linear(self.hid_d, self.hid_d))
         self.fc_g5 = self.weight_norm(nn.Linear(self.hid_d, 1))
 
-    def forward(
-        self, x, cond_tensor, mask
-    ):  # x [B,N,F]    cond_tensor B,C     mask B,N,1
+    def forward(self, x, cond_tensor, mask):
+        # x [B,N,F]    cond_tensor B,C     mask B,N,1
         # local encoding
         x_local = F.leaky_relu(self.fc_l1(x))
         x_local = F.leaky_relu(self.fc_l2(x_local) + x_local)
 
         # global features: masked
         x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
-        x_sum = (x_local * mask).sum(
-            1, keepdim=False
-        ) * self.sum_scale  # mean over points dim.
+        # mean over points dim.
+        x_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x_global = torch.cat([x_mean, x_sum, cond_tensor], 1)
         x_global = F.leaky_relu(self.fc_g1(x_global))
         x_global = F.leaky_relu(self.fc_g2(x_global))  # projecting down to latent size
 
         # equivariant connections
         for i in range(self.equiv_layers):
-            x_global, x_local = self.nn_list[i](
-                x_global, x_local, cond_tensor, mask
-            )  # contains residual connection
+            # contains residual connection
+            x_global, x_local = self.nn_list[i](x_global, x_local, cond_tensor, mask)
 
         # again masking global features
         x_mean = (x_local * mask).mean(1, keepdim=False)  # mean over points dim.
-        x_sum = (x_local * mask).sum(
-            1, keepdim=False
-        ) * self.sum_scale  # sum over points dim.
+        # sum over points dim.
+        x_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x = torch.cat([x_mean, x_sum, x_global, cond_tensor], 1)
 
         x = F.leaky_relu(self.fc_g3(x))

--- a/models.py
+++ b/models.py
@@ -165,11 +165,10 @@ class EPiC_discriminator_mask(nn.Module):
             x_global, x_local = self.nn_list[i](x_global, x_local, mask)
 
         # again masking global features
-        x_mean = (x_local * mask).mean(1, keepdim=False)
         # mean over points dim.
-        x_sum = (x_local * mask).sum(
-            1, keepdim=False
-        ) * self.sum_scale  # sum over points dim.
+        x_mean = (x_local * mask).mean(1, keepdim=False)
+        # sum over points dim.
+        x_sum = (x_local * mask).sum(1, keepdim=False) * self.sum_scale
         x = torch.cat([x_mean, x_sum, x_global], 1)
 
         x = F.leaky_relu(self.fc_g3(x))
@@ -195,12 +194,10 @@ class EPiC_layer_cond_mask(nn.Module):
         self.fc_local2 = weight_norm(nn.Linear(hid_dim, hid_dim))
         self.sum_scale = sum_scale
 
-    def forward(
-        self, x_global, x_local, cond_tensor, mask
-    ):  # shapes: 
+    def forward(self, x_global, x_local, cond_tensor, mask):  # shapes:
         # - x_global[b,latent]
-        # - x_local[b,n,latent_local]  
-        # - points_tensor [b,cond_feats]   
+        # - x_local[b,n,latent_local]
+        # - points_tensor [b,cond_feats]
         # - mask[B,N,1]
         # mask: all non-padded values = True      all zero padded = False
         batch_size, n_points, latent_local = x_local.size()


### PR DESCRIPTION
The `expand` that was used in the `x_local * mask` multiplication was not needed.

When multiplying a tensor `x_local` of size `(B, N, F)` with a mask/tensor `mask` of size `(B, N, 1)`, the third whole third axis of the tensor `x_local` will be multiplied with the corresponding value from the mask

For documentation:

![image](https://user-images.githubusercontent.com/46069353/224339893-c9823592-ed4f-471a-b9fb-02586018e711.png)

